### PR TITLE
Add batch delete for favorite products

### DIFF
--- a/mall-portal/src/main/java/com/macro/mall/portal/controller/MemberProductCollectionController.java
+++ b/mall-portal/src/main/java/com/macro/mall/portal/controller/MemberProductCollectionController.java
@@ -12,6 +12,8 @@ import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 /**
  * 会员商品收藏管理Controller
  * Created by macro on 2018/8/2.
@@ -41,6 +43,21 @@ public class MemberProductCollectionController {
     @ResponseBody
     public CommonResult delete(Long productId) {
         int count = memberCollectionService.delete(productId);
+        if (count > 0) {
+            return CommonResult.success(count);
+        } else {
+            return CommonResult.failed();
+        }
+    }
+
+    @ApiOperation("批量删除商品收藏")
+    @RequestMapping(value = "/deleteBatch", method = RequestMethod.POST)
+    @ResponseBody
+    public CommonResult deleteBatch(@RequestBody List<Long> productIds) {
+        if (productIds == null || productIds.isEmpty()) {
+            return CommonResult.failed("商品ID列表不能为空");
+        }
+        int count = memberCollectionService.deleteBatch(productIds);
         if (count > 0) {
             return CommonResult.success(count);
         } else {

--- a/mall-portal/src/main/java/com/macro/mall/portal/repository/MemberProductCollectionRepository.java
+++ b/mall-portal/src/main/java/com/macro/mall/portal/repository/MemberProductCollectionRepository.java
@@ -5,6 +5,8 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.mongodb.repository.MongoRepository;
 
+import java.util.List;
+
 /**
  * 会员商品收藏Repository
  * Created by macro on 2018/8/2.
@@ -29,4 +31,9 @@ public interface MemberProductCollectionRepository extends MongoRepository<Membe
      * 根据会员ID删除记录
      */
     void deleteAllByMemberId(Long memberId);
+
+    /**
+     * 根据会员ID和商品ID集合删除记录
+     */
+    int deleteByMemberIdAndProductIdIn(Long memberId, List<Long> productIds);
 }

--- a/mall-portal/src/main/java/com/macro/mall/portal/service/MemberCollectionService.java
+++ b/mall-portal/src/main/java/com/macro/mall/portal/service/MemberCollectionService.java
@@ -3,6 +3,8 @@ package com.macro.mall.portal.service;
 import com.macro.mall.portal.domain.MemberProductCollection;
 import org.springframework.data.domain.Page;
 
+import java.util.List;
+
 /**
  * 会员商品收藏管理Service
  * Created by macro on 2018/8/2.
@@ -17,6 +19,11 @@ public interface MemberCollectionService {
      * 删除收藏
      */
     int delete(Long productId);
+
+    /**
+     * 批量删除收藏
+     */
+    int deleteBatch(List<Long> productIds);
 
     /**
      * 分页查询收藏

--- a/mall-portal/src/main/java/com/macro/mall/portal/service/impl/MemberCollectionServiceImpl.java
+++ b/mall-portal/src/main/java/com/macro/mall/portal/service/impl/MemberCollectionServiceImpl.java
@@ -14,6 +14,8 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+
 /**
  * 会员收藏Service实现类
  * Created by macro on 2018/8/2.
@@ -61,6 +63,12 @@ public class MemberCollectionServiceImpl implements MemberCollectionService {
     public int delete(Long productId) {
         UmsMember member = memberService.getCurrentMember();
         return productCollectionRepository.deleteByMemberIdAndProductId(member.getId(), productId);
+    }
+
+    @Override
+    public int deleteBatch(List<Long> productIds) {
+        UmsMember member = memberService.getCurrentMember();
+        return productCollectionRepository.deleteByMemberIdAndProductIdIn(member.getId(), productIds);
     }
 
     @Override


### PR DESCRIPTION
Related to #31

Add batch deletion of favorite products API.

* **Controller Changes**
  - Add a new endpoint `deleteBatch` in `MemberProductCollectionController` to handle batch deletion of favorite products.
  - Accept a list of product IDs as input and return an error if the list is empty.
  - Call the `deleteBatch` method in `MemberCollectionService` if the list is not empty.

* **Service Changes**
  - Add a new method `deleteBatch` in `MemberCollectionService` to handle batch deletion of favorite products.
  - Implement the `deleteBatch` method in `MemberCollectionServiceImpl` to delete the favorite products in the list.

* **Repository Changes**
  - Add a new method `deleteByMemberIdAndProductIdIn` in `MemberProductCollectionRepository` to handle batch deletion of favorite products by member ID and product ID list.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/sxthunder/mall/issues/31?shareId=e20435ce-2c83-46ca-affa-91115a671e17).