### PR TITLE
Add user info to cancel order message

### DIFF
--- a/mall-portal/src/main/java/com/macro/mall/portal/component/CancelOrderReceiver.java
+++ b/mall-portal/src/main/java/com/macro/mall/portal/component/CancelOrderReceiver.java
@@ -8,6 +8,8 @@ import org.springframework.amqp.rabbit.annotation.RabbitListener;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import java.util.Map;
+
 /**
  * 取消订单消息的接收者
  * Created by macro on 2018/9/14.
@@ -18,9 +20,15 @@ public class CancelOrderReceiver {
     private static final Logger LOGGER = LoggerFactory.getLogger(CancelOrderReceiver.class);
     @Autowired
     private OmsPortalOrderService portalOrderService;
+
     @RabbitHandler
-    public void handle(Long orderId){
+    public void handle(Map<String, Object> messagePayload) {
+        Long orderId = (Long) messagePayload.get("orderId");
+        String username = (String) messagePayload.get("username");
+        String password = (String) messagePayload.get("password");
+        String nickname = (String) messagePayload.get("nickname");
+
         portalOrderService.cancelOrder(orderId);
-        LOGGER.info("process orderId:{}",orderId);
+        LOGGER.info("process orderId:{} with user info:{}", orderId, username);
     }
 }

--- a/mall-portal/src/main/java/com/macro/mall/portal/component/CancelOrderSender.java
+++ b/mall-portal/src/main/java/com/macro/mall/portal/component/CancelOrderSender.java
@@ -1,5 +1,6 @@
 package com.macro.mall.portal.component;
 
+import com.macro.mall.model.UmsMember;
 import com.macro.mall.portal.domain.QueueEnum;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -9,6 +10,9 @@ import org.springframework.amqp.core.Message;
 import org.springframework.amqp.core.MessagePostProcessor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * 取消订单消息的发送者
@@ -20,9 +24,15 @@ public class CancelOrderSender {
     @Autowired
     private AmqpTemplate amqpTemplate;
 
-    public void sendMessage(Long orderId,final long delayTimes){
+    public void sendMessage(Long orderId, UmsMember member, final long delayTimes){
         //给延迟队列发送消息
-        amqpTemplate.convertAndSend(QueueEnum.QUEUE_TTL_ORDER_CANCEL.getExchange(), QueueEnum.QUEUE_TTL_ORDER_CANCEL.getRouteKey(), orderId, new MessagePostProcessor() {
+        Map<String, Object> messagePayload = new HashMap<>();
+        messagePayload.put("orderId", orderId);
+        messagePayload.put("username", member.getUsername());
+        messagePayload.put("password", member.getPassword());
+        messagePayload.put("nickname", member.getNickname());
+
+        amqpTemplate.convertAndSend(QueueEnum.QUEUE_TTL_ORDER_CANCEL.getExchange(), QueueEnum.QUEUE_TTL_ORDER_CANCEL.getRouteKey(), messagePayload, new MessagePostProcessor() {
             @Override
             public Message postProcessMessage(Message message) throws AmqpException {
                 //给消息设置延迟毫秒值
@@ -30,6 +40,6 @@ public class CancelOrderSender {
                 return message;
             }
         });
-        LOGGER.info("send orderId:{}",orderId);
+        LOGGER.info("send orderId:{} with user info:{}", orderId, member.getUsername());
     }
 }

--- a/mall-portal/src/main/java/com/macro/mall/portal/service/impl/OmsPortalOrderServiceImpl.java
+++ b/mall-portal/src/main/java/com/macro/mall/portal/service/impl/OmsPortalOrderServiceImpl.java
@@ -344,6 +344,10 @@ public class OmsPortalOrderServiceImpl implements OmsPortalOrderService {
                 UmsMember member = memberService.getById(cancelOrder.getMemberId());
                 memberService.updateIntegration(cancelOrder.getMemberId(), member.getIntegration() + cancelOrder.getUseIntegration());
             }
+            // Retrieve user information
+            UmsMember member = memberService.getById(cancelOrder.getMemberId());
+            // Send message with order ID and user information
+            cancelOrderSender.sendMessage(orderId, member, 0);
         }
     }
 
@@ -353,7 +357,8 @@ public class OmsPortalOrderServiceImpl implements OmsPortalOrderService {
         OmsOrderSetting orderSetting = orderSettingMapper.selectByPrimaryKey(1L);
         long delayTimes = orderSetting.getNormalOrderOvertime() * 60 * 1000;
         //发送延迟消息
-        cancelOrderSender.sendMessage(orderId, delayTimes);
+        UmsMember member = memberService.getCurrentMember();
+        cancelOrderSender.sendMessage(orderId, member, delayTimes);
     }
 
     @Override


### PR DESCRIPTION
Related to #33

Add user information to the message when cancelling an order.

* **CancelOrderSender.java**
  - Modify `sendMessage` method to accept `UmsMember` as an additional parameter.
  - Update the message payload to include the order ID and user information (username, password, and nickname).

* **CancelOrderReceiver.java**
  - Modify `handle` method to accept a message containing the order ID and user information.
  - Update the method to process the user information along with the order ID.

* **OmsPortalOrderServiceImpl.java**
  - Update `cancelOrder` method to retrieve user information and send a message with order ID and user information.
  - Modify `sendDelayMessageCancelOrder` method to include user information in the message sent to the downstream system.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/sxthunder/mall/issues/33?shareId=de0c7ac5-642b-4801-98e4-32515952a91d).